### PR TITLE
Add algorithm explanation diagram

### DIFF
--- a/model training/algorithm_diagram.svg
+++ b/model training/algorithm_diagram.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" font-family="Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="20" y="50" width="150" height="100" rx="10" ry="10" fill="#e0f0ff" stroke="#000"/>
+  <text x="95" y="95" text-anchor="middle" font-size="14">Input Images</text>
+  <text x="95" y="115" text-anchor="middle" font-size="14">+ Sensor Data</text>
+
+  <rect x="220" y="50" width="150" height="100" rx="10" ry="10" fill="#e0f0ff" stroke="#000"/>
+  <text x="295" y="95" text-anchor="middle" font-size="14">YOLO</text>
+  <text x="295" y="115" text-anchor="middle" font-size="14">Person Detection</text>
+
+  <rect x="420" y="50" width="150" height="100" rx="10" ry="10" fill="#e0f0ff" stroke="#000"/>
+  <text x="495" y="95" text-anchor="middle" font-size="14">EfficientNet</text>
+  <text x="495" y="115" text-anchor="middle" font-size="14">Activity Classifier</text>
+
+  <rect x="620" y="50" width="150" height="100" rx="10" ry="10" fill="#e0f0ff" stroke="#000"/>
+  <text x="695" y="90" text-anchor="middle" font-size="14">Temporal +</text>
+  <text x="695" y="110" text-anchor="middle" font-size="14">Sensor Fusion</text>
+  <text x="695" y="130" text-anchor="middle" font-size="14">Activity Recognition</text>
+
+  <line x1="170" y1="100" x2="220" y2="100" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="370" y1="100" x2="420" y2="100" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="570" y1="100" x2="620" y2="100" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add SVG diagram illustrating the person detection, activity classification, and sensor fusion steps from `model.ipynb`.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689786c4b72883299843338c7b497e21